### PR TITLE
Fix unpublished pages not removed from Elasticsearch index

### DIFF
--- a/src/Extension/SearchableDataObjectExtension.php
+++ b/src/Extension/SearchableDataObjectExtension.php
@@ -289,12 +289,7 @@ class SearchableDataObjectExtension extends DataExtension
 
     public function onAfterUnpublish()
     {
-        // Skip if already unpublished from a delete() call
-        if (!$this->owner->isPublished()) {
-            return false;
-        }
-
-        if ($this->isIndexed()) {
+        if (!empty($this->owner->GUID)) {
             $this->removeFromIndex();
         }
     }


### PR DESCRIPTION
## Summary
- Fixes a bug where unpublished/archived pages were never removed from the Elasticsearch index
- The `onAfterUnpublish()` method checked `!isPublished()` which is always `true` after unpublishing, causing the early return to trigger on every unpublish call
- Documents accumulated in the index over time (e.g. 1,517 docs vs 1,249 live pages on CSNZ)

## Changes
- Removed the broken `!isPublished()` guard in `onAfterUnpublish()`
- Now simply checks the page has a GUID and calls `removeFromIndex()`
- The `onAfterDelete()` method already handles the delete case separately, so no double-removal concern

## Ticket
Freshdesk #26335