### PR TITLE
Fix stale documents remaining in index after unpublish/delete

### DIFF
--- a/src/Extension/SearchableDataObjectExtension.php
+++ b/src/Extension/SearchableDataObjectExtension.php
@@ -289,12 +289,7 @@ class SearchableDataObjectExtension extends DataExtension
 
     public function onAfterUnpublish()
     {
-        // Skip if already unpublished from a delete() call
-        if (!$this->owner->isPublished()) {
-            return false;
-        }
-
-        if ($this->isIndexed()) {
+        if (!empty($this->owner->GUID)) {
             $this->removeFromIndex();
         }
     }
@@ -307,7 +302,7 @@ class SearchableDataObjectExtension extends DataExtension
     {
         parent::onAfterDelete();
 
-        if ($this->isIndexed()) {
+        if (!empty($this->owner->GUID)) {
             $this->removeFromIndex();
         }
     }


### PR DESCRIPTION
## Summary
- `onAfterUnpublish()` had a broken `isPublished()` check that always returned early, making the method a no-op
- `onAfterDelete()` used `isIndexed()` which returns false for pages with `ShowInSearch=0`, preventing removal from the index
- Both methods now check for a GUID instead, ensuring any previously indexed document is removed regardless of current `ShowInSearch` status

## Changes
- `src/Extension/SearchableDataObjectExtension.php`: Replace `isIndexed()` / `isPublished()` guards with GUID check in `onAfterUnpublish()` and `onAfterDelete()`